### PR TITLE
Fix provider path comments

### DIFF
--- a/frontend/lib/core/presentation/providers/auth_provider.dart
+++ b/frontend/lib/core/presentation/providers/auth_provider.dart
@@ -1,4 +1,4 @@
-// lib/providers/auth_provider.dart
+// lib/core/presentation/providers/auth_provider.dart
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:convert'; // Para jsonEncode e jsonDecode

--- a/frontend/lib/core/presentation/providers/customer_provider.dart
+++ b/frontend/lib/core/presentation/providers/customer_provider.dart
@@ -1,4 +1,4 @@
-// frontend/lib/core/presentation/providers/customer_provider.dart
+// lib/core/presentation/providers/customer_provider.dart
 import "package:flutter/widgets.dart";
 import "../../data/models/customer_model.dart";
 import "../../data/datasources/api_service.dart";

--- a/frontend/lib/core/presentation/providers/dashboard_provider.dart
+++ b/frontend/lib/core/presentation/providers/dashboard_provider.dart
@@ -1,4 +1,4 @@
-// lib/providers/dashboard_provider.dart
+// lib/core/presentation/providers/dashboard_provider.dart
 import 'package:flutter/foundation.dart';
 import '../../data/datasources/api_service.dart';
 import '../../../shared/utils/error_handler.dart';

--- a/frontend/lib/core/presentation/providers/item_group_provider.dart
+++ b/frontend/lib/core/presentation/providers/item_group_provider.dart
@@ -1,4 +1,4 @@
-// frontend/lib/providers/item_group_provider.dart
+// lib/core/presentation/providers/item_group_provider.dart
 import "package:flutter/widgets.dart";
 import "../../data/models/item_group_model.dart";
 import "../../data/datasources/api_service.dart";

--- a/frontend/lib/core/presentation/providers/layout_provider.dart
+++ b/frontend/lib/core/presentation/providers/layout_provider.dart
@@ -1,4 +1,4 @@
-// lib/providers/layout_provider.dart
+// lib/core/presentation/providers/layout_provider.dart
 import 'package:flutter/material.dart';
 import '../../../shared/utils/app_prefs.dart';
 

--- a/frontend/lib/core/presentation/providers/stock_provider.dart
+++ b/frontend/lib/core/presentation/providers/stock_provider.dart
@@ -1,4 +1,4 @@
-// frontend/lib/providers/stock_provider.dart
+// lib/core/presentation/providers/stock_provider.dart
 import "package:flutter/foundation.dart";
 import "../../data/models/stock_item.dart";
 import "../../data/datasources/api_service.dart";

--- a/frontend/lib/core/presentation/providers/store_provider.dart
+++ b/frontend/lib/core/presentation/providers/store_provider.dart
@@ -1,4 +1,4 @@
-// lib/providers/store_provider.dart
+// lib/core/presentation/providers/store_provider.dart
 import 'package:flutter/foundation.dart';
 import '../../data/models/store_model.dart';
 import '../../data/datasources/api_service.dart';

--- a/frontend/lib/core/presentation/providers/supplier_provider.dart
+++ b/frontend/lib/core/presentation/providers/supplier_provider.dart
@@ -1,4 +1,4 @@
-// frontend/lib/providers/supplier_provider.dart
+// lib/core/presentation/providers/supplier_provider.dart
 import "package:flutter/widgets.dart";
 import "../../data/models/supplier_model.dart";
 import "../../data/datasources/api_service.dart";


### PR DESCRIPTION
## Summary
- correct path comments in provider headers under `lib/core/presentation/providers`

## Testing
- `npm test` *(fails: Cannot find module 'sqlite3')*
- `npm run test:security` *(fails: Cannot find module 'axios')*
- `flutter test` *(fails: command not found)*
- `flutter test integration_test/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844dbbcb68c832696e8dde37fa779a4