### PR TITLE
Update document header date handling

### DIFF
--- a/backend/src/controllers/documentController.js
+++ b/backend/src/controllers/documentController.js
@@ -118,7 +118,7 @@ exports.createDocument = catchAsync(async (req, res, next) => {
 exports.updateDocumentHeader = catchAsync(async (req, res, next) => {
     const storeId = validateId(req.params.storeId, 'ID da loja');
     const documentId = validateId(req.params.documentId, 'ID do documento');
-    const { date, customerId, supplierId, notes } = req.body;
+    const { date, document_date, customerId, supplierId, notes } = req.body;
 
     const existingDoc = await db.findDocumentByIdAndStore(documentId, storeId);
     if (!existingDoc) {
@@ -128,7 +128,7 @@ exports.updateDocumentHeader = catchAsync(async (req, res, next) => {
     // TODO: Adicionar lógica para impedir edição se o documento estiver "fechado" ou "processado"
 
     const result = await db.updateDocumentHeaderDetails(documentId, storeId, {
-        date: date || existingDoc.date, // Manter data se não fornecida
+        date: document_date || date || existingDoc.document_date, // Manter data se não fornecida
         customerId: customerId === undefined ? existingDoc.customer_id : customerId, // Permite setar para null
         supplierId: supplierId === undefined ? existingDoc.supplier_id : supplierId, // Permite setar para null
         notes: notes === undefined ? existingDoc.notes : notes?.trim() || null,

--- a/backend/test_update_document_date.js
+++ b/backend/test_update_document_date.js
@@ -1,0 +1,54 @@
+const db = require('./src/data/database');
+const documentController = require('./src/controllers/documentController');
+
+async function runTest() {
+  try {
+    await db.connectDb();
+    await db.createTables();
+
+    // Create sample store
+    const storeRes = await db.createStoreDB({ name: 'Date Test Store', address: 'Test Ave' });
+    const storeId = storeRes.lastID;
+
+    // Create stock item
+    const itemRes = await db.createStockItemInStore({ storeId, name: 'Sample Item', quantity: 50 });
+    const itemId = itemRes.lastID;
+
+    // Create a document
+    const docRes = await db.createDocumentHeader({
+      storeId,
+      type: 'purchase',
+      date: '2024-01-01',
+      customerId: null,
+      supplierId: null,
+      notes: 'initial',
+      totalAmount: 0
+    });
+    const documentId = docRes.lastID;
+    await db.createDocumentItem({ documentId, itemId, quantity: 5, unitPrice: 1 });
+
+    // Prepare mock request/response
+    const req = {
+      params: { storeId: storeId.toString(), documentId: documentId.toString() },
+      body: { document_date: '2024-02-01' }
+    };
+    const res = {
+      statusCode: 0,
+      status(code) { this.statusCode = code; return this; },
+      json(data) { console.log('Response:', JSON.stringify(data)); }
+    };
+    const next = (err) => { if (err) console.error('Error:', err); };
+
+    // Run update
+    documentController.updateDocumentHeader(req, res, next);
+    await new Promise(r => setTimeout(r, 100));
+
+    const updated = await db.findDocumentByIdAndStore(documentId, storeId);
+    console.log('Updated document_date:', updated.document_date);
+    console.log('==end==');
+  } catch (e) {
+    console.error('Test failed:', e);
+  }
+}
+
+runTest();


### PR DESCRIPTION
## Summary
- allow `document_date` to update document headers
- add a manual script to verify header date updates

## Testing
- `npm test --silent`
- `npm run test:security --silent` *(fails: server not running)*
- `node test_update_document_date.js`

------
https://chatgpt.com/codex/tasks/task_e_6844dbc6fb1083268eeb81fc5b5b8ccc