### PR TITLE
Implement local notification service

### DIFF
--- a/frontend/lib/core/presentation/providers/dashboard_provider.dart
+++ b/frontend/lib/core/presentation/providers/dashboard_provider.dart
@@ -2,6 +2,8 @@
 import 'package:flutter/foundation.dart';
 import '../../data/datasources/api_service.dart';
 import '../../../shared/utils/error_handler.dart';
+import '../../../shared/utils/app_prefs.dart';
+import '../../../shared/services/notification_service.dart';
 import '../../data/models/stock_item.dart';
 import '../../data/models/document_model.dart';
 import '../../data/models/customer_model.dart';
@@ -138,6 +140,12 @@ class DashboardProvider with ChangeNotifier, ErrorHandlingMixin {
         lowStockItems: lowStockCount,
         documentsByType: docsByType,
       );
+
+      final showNotifications =
+          await AppPrefs.getBool('showNotifications') ?? true;
+      if (showNotifications && lowStockCount > 0) {
+        NotificationService.showLowStockNotification(lowStockCount);
+      }
 
       debugPrint("[DashboardProvider] Estatísticas carregadas: ${_stats.totalProducts} produtos, ${_stats.totalDocuments} documentos");
     }, 'fetchDashboardStats');

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -41,6 +41,7 @@ import 'core/presentation/screens/help_screen.dart';
 // Importar Utilitários e Preferências
 import 'shared/utils/app_prefs.dart';
 import 'core/data/datasources/api_service.dart';
+import 'shared/services/notification_service.dart';
 
 // Clean Architecture
 import 'shared/dependency_injection.dart';
@@ -83,6 +84,9 @@ void main() async {
   // Necessário para garantir que plugins (como SharedPreferences) sejam inicializados
   // antes de `runApp` se você usar `await` antes dele (como fizemos em AppPrefs).
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Inicializa o serviço de notificações locais
+  await NotificationService.initialize();
 
   // Initialize Clean Architecture dependencies
   await initializeDependencies();

--- a/frontend/lib/shared/services/notification_service.dart
+++ b/frontend/lib/shared/services/notification_service.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+class NotificationService {
+  static final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  static Future<void> initialize() async {
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosSettings = DarwinInitializationSettings();
+    const settings = InitializationSettings(android: androidSettings, iOS: iosSettings);
+    await _plugin.initialize(settings);
+  }
+
+  static Future<void> showNotification({
+    required int id,
+    required String title,
+    required String body,
+  }) async {
+    const androidDetails = AndroidNotificationDetails(
+      'default_channel',
+      'Notificacoes',
+      channelDescription: 'Notificacoes gerais do aplicativo',
+      importance: Importance.high,
+      priority: Priority.high,
+    );
+    const iosDetails = DarwinNotificationDetails();
+    const details = NotificationDetails(android: androidDetails, iOS: iosDetails);
+    await _plugin.show(id, title, body, details);
+  }
+
+  static Future<void> showLowStockNotification(int count) async {
+    await showNotification(
+      id: 100,
+      title: 'Estoque Baixo',
+      body: 'Existem $count itens com estoque baixo.',
+    );
+  }
+}

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   path: ^1.8.3
   excel: ^4.0.6
   csv: ^6.0.0
+  flutter_local_notifications: ^15.1.1
   # Clean Architecture dependencies
   equatable: ^2.0.5
   get_it: ^7.6.4


### PR DESCRIPTION
## Summary
- add `flutter_local_notifications` package
- initialize notification service in `main.dart`
- notify low stock items in dashboard provider
- implement `NotificationService`

## Testing
- `npm test` *(fails: mocha not found)*
- `flutter test` *(fails: command not found)*
- `flutter test integration_test/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e18ac4f083269a4c2ee41fe6e74c