### PR TITLE
Fix Android build by enabling desugaring

### DIFF
--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -13,6 +13,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        // Enable core library desugaring for libraries that require Java 8+ APIs
+        coreLibraryDesugaringEnabled true
     }
 
     kotlinOptions {
@@ -37,4 +39,10 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    // Desugaring library to support newer Java language features on older
+    // Android runtimes.
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.0.4"
 }


### PR DESCRIPTION
## Summary
- enable core library desugaring in Android build
- add `desugar_jdk_libs` dependency

## Testing
- `flutter test` *(fails: command not found)*
- `flutter test integration_test/` *(fails: command not found)*
- `npm test` *(fails: mocha not found)*
- `npm run test:security` *(fails: module 'axios' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e435634c832697a9fa6d0eef8038